### PR TITLE
Some changes for GKE

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -23,11 +23,20 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: self-hosted-runner-creds
-                key: TOKEN
+                key: GITHUB_TOKEN
           - name: DOCKER_HOST
             value: 127.0.0.1
           - name: DOCKER_BUILDKIT
             value: "1"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                [
+              '/bin/bash',
+              '-c',
+              'RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token $(curl -sS --data "" -H "Authorization: Bearer $TOKEN" https://api.github.com/repos/$GITHUB_REPO/actions/runners/remove-token | jq -r .token)'
+                ]
         resources:
             limits:
               memory: "512Mi"

--- a/deployment.yml
+++ b/deployment.yml
@@ -23,7 +23,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: self-hosted-runner-creds
-                key: GITHUB_TOKEN
+                key: TOKEN
           - name: DOCKER_HOST
             value: 127.0.0.1
           - name: DOCKER_BUILDKIT

--- a/startup.sh
+++ b/startup.sh
@@ -11,7 +11,7 @@ function remove_runner {
 # Watch for EXIT signal to be able to shut down gracefully
 trap remove_runner EXIT
 
-# Generate 
+# Generate
 CONFIG_TOKEN=$(curl --data "" --header "Authorization: Bearer $TOKEN" https://api.github.com/repos/$GITHUB_REPO/actions/runners/registration-token | jq -r '.token')
 
 # Create the runner and configure it

--- a/startup.sh
+++ b/startup.sh
@@ -15,7 +15,7 @@ trap remove_runner EXIT
 CONFIG_TOKEN=$(curl --data "" --header "Authorization: Bearer $TOKEN" https://api.github.com/repos/$GITHUB_REPO/actions/runners/registration-token | jq -r '.token')
 
 # Create the runner and configure it
-./config.sh --url https://github.com/$GITHUB_REPO --token $CONFIG_TOKEN --unattended
+./config.sh --url https://github.com/$GITHUB_REPO --token $CONFIG_TOKEN --unattended --replace
 
 # Run it
 ./runsvc.sh


### PR DESCRIPTION
fixes #2 
Changelist:

- Fixed a readme instruction as GITHUB_REPO is expected as `<owner>/<repo>`
- Introduce lifecycle hook instead of capturing exit signal
- Use --replace flag in config.sh so that runner can restart without error
- Launch the runner as a service instead of interactive mode (based on comment @bryanmacfarlane by here: https://github.com/actions/runner/issues/246#issuecomment-615293718)